### PR TITLE
Scrum 51 define secure default storage location

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,7 +25,10 @@ app.use(cors());
 app.use(express.json());
 
 // Create uploads directory if it doesn't exist
+
+
 const uploadsDir = join(dirname(__dirname), 'uploads');
+console.log("uploadsDir is: " + uploadsDir)
 mkdirSync(uploadsDir, { recursive: true });
 
 const lmStudio = new LMStudioService();

--- a/backend/src/services/StorageService.ts
+++ b/backend/src/services/StorageService.ts
@@ -1,7 +1,9 @@
 import { mkdir, rm, cp, writeFile } from 'fs/promises';
 import { join, dirname, extname } from 'path';
 import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
 
+dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -19,9 +21,9 @@ export class StorageService {
 
   constructor(config?: Partial<StorageConfig>) {
     this.config = {
-      rootDir: join(dirname(dirname(__dirname)), 'uploads'),
-      allowedTypes: ['.pdf', '.docx', '.doc', '.txt', '.md'],
-      maxFileSize: 10 * 1024 * 1024, // 10MB
+      rootDir: process.env.STORAGE_ROOT || join(dirname(dirname(__dirname)), 'secure-storage'),
+      allowedTypes: process.env.STORAGE_ALLOWED_TYPES?.split(',') || ['.pdf', '.docx', '.doc', '.txt', '.md'],
+      maxFileSize: parseInt(process.env.STORAGE_MAX_FILE_SIZE || '') || 10 * 1024 * 1024,
       ...config
     };
 

--- a/run.sh
+++ b/run.sh
@@ -64,7 +64,17 @@ else
 fi
 
 # Update .env with the LM Studio URL
-echo "LM_STUDIO_URL=$LM_STUDIO_URL" > backend/.env
+ENV_FILE="backend/.env"
+
+# Preserve existing .env settings, update or append LM_STUDIO_URL
+if grep -q "^LM_STUDIO_URL=" "$ENV_FILE"; then
+  # Replace existing LM_STUDIO_URL
+  sed -i '' "s|^LM_STUDIO_URL=.*|LM_STUDIO_URL=$LM_STUDIO_URL|" "$ENV_FILE"
+else
+  # Append LM_STUDIO_URL if not found
+  echo "LM_STUDIO_URL=$LM_STUDIO_URL" >> "$ENV_FILE"
+fi
+
 
 # Print connection info
 echo "================================================================="


### PR DESCRIPTION
Updated the storageService code to allow for the .env files' variables. 
Updated the bash script so that .env files wouldn't be altered when running code.

FR1: The application shall default to /var/app/storage/ as the storage root when the STORAGE_ROOT environment variable is not set.

FR2: The application shall allow overriding the storage root via the STORAGE_ROOT environment variable.

FR3: The application shall define a list of allowed MIME types via the STORAGE_ALLOWED_TYPES environment variable.

FR4: The application shall define the maximum allowed file size via the STORAGE_MAX_FILE_SIZE environment variable (default: 10MB).

